### PR TITLE
Make mm* scripts compatible with both Python 2 and 3

### DIFF
--- a/2017-06-29-ssdp/mmhistogram
+++ b/2017-06-29-ssdp/mmhistogram
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 import argparse
 import itertools
 import math
@@ -34,7 +34,7 @@ maxval = M[0]
 avgval = sum(M) / float(len(M))
 devval = math.sqrt(sum([(m - avgval)**2 for m in M]) / float(len(M)))
 
-medval = M[len(M)/2]
+medval = M[int(len(M) / 2)]
 
 KV = []
 
@@ -65,7 +65,7 @@ maxcount = float(max(c for _, _, c in KV))
 maxbound = KV[-1][0]
 boundl = max(len(str(maxbound)), len('value'))
 
-print "%s min:%.2f avg:%.2f med=%.2f max:%.2f dev:%.2f count:%d" % (
+print("%s min:%.2f avg:%.2f med=%.2f max:%.2f dev:%.2f count:%d" % (
     args.title,
     minval,
     avgval,
@@ -73,27 +73,27 @@ print "%s min:%.2f avg:%.2f med=%.2f max:%.2f dev:%.2f count:%d" % (
     maxval,
     devval,
     totalcount,
-)
-print "%s:" % (
+))
+print("%s:" % (
     args.title,
-)
-print "%*s |%*s %s" % (
+))
+print("%*s |%*s %s" % (
     boundl+1,
     "value",
     args.columns,
     "-" * args.columns,
     "count"
-)
+))
 
 for boundb, bound, c in KV:
     if args.percentage:
         cp = "%5.2f%%" % ((c / float(totalcount))*100.0,)
     else:
         cp = "%d" % (c,)
-    print "%*d |%*s %s" % (
+    print("%*d |%*s %s" % (
         boundl + 1,
         boundb,
         args.columns,
         "*" * int(args.columns * (c/maxcount)),
         cp
-    )
+    ))

--- a/2017-06-29-ssdp/mmsum
+++ b/2017-06-29-ssdp/mmsum
@@ -6,4 +6,4 @@ s = 0
 for line in sys.stdin:
     s += float(line)
 
-print s
+print(s)

--- a/2017-06-29-ssdp/mmwatch
+++ b/2017-06-29-ssdp/mmwatch
@@ -31,7 +31,7 @@ def main(cmd):
         t0 = datetime.datetime.now()
         out = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE).communicate()[0]
 
-        p = digits_re.split(out)
+        p = digits_re.split(out.decode())
 
         if len(prevp) != len(p):
             s = p


### PR DESCRIPTION
Changes include:
- Use `print` as a function, not a statement
- Ensure median value in `mmhistogram` is calculated as an integer, not a float
- Convert bytes output from `subprocess.Popen` in `mmwatch` to a string before
  applying a regex to it

All changes has been tested on both Python 2.7.13 and 3.6.1.