### PR TITLE
mmwatch - add support for doing mmwatch on floating point numbers

### DIFF
--- a/2017-06-29-ssdp/mmwatch
+++ b/2017-06-29-ssdp/mmwatch
@@ -7,7 +7,7 @@ import datetime
 import re
 
 
-digits_re = re.compile("([0-9]*)")
+digits_re = re.compile("([0-9eE.+]*)")
 to = 2.0
 CLS='\033[2J\033[;H'
 digit_chars = set('0123456789.')


### PR DESCRIPTION
Sometimes some programs return floats as 1.2345e+06 form. This
didn't work with mmwatch.