### PR TITLE
Disbale keep-alive property for 2016-08-time-out/listener.go 

### DIFF
--- a/2016-08-time-out/listener.go
+++ b/2016-08-time-out/listener.go
@@ -1,5 +1,3 @@
-// This is a trivial TCP server leaking sockets.
-
 package main
 
 import (
@@ -8,7 +6,7 @@ import (
 	"time"
 )
 
-func handle(conn net.Conn) {
+func handle(conn *net.TCPConn) {
 	defer conn.Close()
 	for {
 		time.Sleep(time.Second)
@@ -28,8 +26,14 @@ func main() {
 	for {
 		if conn, err := listener.Accept(); err == nil {
 			i += 1
+			c := conn.(*net.TCPConn)
+			// OS should not send keep-alive messages on the connection.
+			// By default, keep-alive probes are sent with a default value
+			// (currently 15 seconds), if supported by the protocol and operating
+			// system. Hence, SetKeepAlive should be turned off for the experiment.
+			c.SetKeepAlive(false)
 			if i < 800 {
-				go handle(conn)
+				go handle(c)
 			} else {
 				conn.Close()
 			}

--- a/2016-08-time-out/listener.go
+++ b/2016-08-time-out/listener.go
@@ -1,3 +1,5 @@
+// This is a trivial TCP server leaking sockets.
+
 package main
 
 import (


### PR DESCRIPTION
With reference to the amazing blog post "This is strictly a violation of the TCP specification" posted by "Marek Majkowski" (@majek), I'd like to open a PR.

While I was validating using the example program, I came across a glitch. I know this is because of the different Go version's. I'm using `go version go1.14.3`.

If `keep-alive` is `enabled`:
```
ss -en4tp '( sport = :5000 or dport = :5000 )'                                                                                              

State	   Recv-Q Send-Q Local Address:Port               Peer Address:Port
ESTAB	   0	  0	 127.0.0.1:5000               127.0.0.1:51512               users:(("server",pid=40195,fd=9)) timer:(keepalive,9.647ms,0) ino:1933904524 sk:ffff9
bddd466ce00 <->
ESTAB	   0	  0	 127.0.0.1:51512              127.0.0.1:5000                users:(("nc",pid=51373,fd=3)) ino:1933933442 sk:ffff8bdcc565ec80 <->
```
Notice the `keep-alive (15s) timer`. If `nc` is closed:

```
ss -en4tp '( sport = :5000 or dport = :5000 )'  

State	   Recv-Q Send-Q Local Address:Port               Peer Address:Port
CLOSE-WAIT 1	  0	 127.0.0.1:5000               127.0.0.1:51512               users:(("server",pid=40195,fd=9)) timer:(keepalive,10sec,0) ino:1933904524 sk:ffff9
bddd466ce00 -->
FIN-WAIT-2 0	  0	 127.0.0.1:51512              127.0.0.1:5000                timer:(timewait,55sec,0) ino:0 sk:ffff8bdcc565ec80
```
Notice the client's (nc) `timewait` timer starts from 60 seconds after which the socket is closed. After it's closed, when server's keepalive ticker hits 0, that socket is also closed as well. So, no stuck `CLOSE_WAIT` socket.

So, yes keep-alive property working as expected (enabled by default).

If `keep-alive` is `disabled`:
```
ss -en4tp '( sport = :5000 or dport = :5000 )' 

State	   Recv-Q Send-Q Local Address:Port               Peer Address:Port
FIN-WAIT-2 0	  0	 127.0.0.1:52546              127.0.0.1:5000                timer:(timewait,55sec,0) ino:0 sk:ffff9bddcbf9c800
CLOSE-WAIT 1	  0	 127.0.0.1:5000               127.0.0.1:52546               users:(("server",pid=46874,fd=4)) ino:1934014864 sk:ffff9bddc465a6c0 -->
```

Notice when `nc` is closed, `timewait` timer is there but not the `keepalive` timer for the server. Now the socket is stuck with `CLOSE_WAIT` status even after socket with `FIN-WAIT-2` status disappears.

Hence, I think it'll be worth mentioning the `keep-alive` property's involvement if possible in your post.

Please do review the PR. I am new to this, so I might not be very clear in explaining my point, but I did what I felt worth mentioning. And I love the Cloudflare's blog and Go. Cheers!