### PR TITLE
docs: fix simple typo, stricly -> strictly

### DIFF
--- a/2018-07-dropping-packets/trunc-loop.c
+++ b/2018-07-dropping-packets/trunc-loop.c
@@ -44,7 +44,7 @@ int main()
 
 	struct mmsghdr messages[MAX_MSG] = {0};
 
-	/* Not stricly needed since the msghdr is zeroed anyway, but let's be
+	/* Not strictly needed since the msghdr is zeroed anyway, but let's be
 	 * explicit */
 	int i;
 	for (i = 0; i < MAX_MSG; i++) {


### PR DESCRIPTION
There is a small typo in 2018-07-dropping-packets/trunc-loop.c.

Should read `strictly` rather than `stricly`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md